### PR TITLE
Fix path of cuda and darknet

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ $ git clone https://github.com/citbrains/dotfiles.git ~
 $ ln -s ~/dotfiles/bashrc ~/.bashrc
 $ ln -s ~/dotfiles/vimrc ~/.vimrc
 $ ln -s ~/dotfiles/tmux.conf ~/.tmux.conf
+$ ln -s ~/dotfiles/darknet_path ~/darknet_path
 $ # VNC autostart
 $ ln -s ~/dotfiles/config/autostart ~/.config/
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,15 @@ $ git clone https://github.com/citbrains/dotfiles.git ~
 $ ln -s ~/dotfiles/bashrc ~/.bashrc
 $ ln -s ~/dotfiles/vimrc ~/.vimrc
 $ ln -s ~/dotfiles/tmux.conf ~/.tmux.conf
-$ ln -s ~/dotfiles/darknet_path ~/darknet_path
 $ # VNC autostart
 $ ln -s ~/dotfiles/config/autostart ~/.config/
+```
+
+### Create a darknet_path
+```bash
+$ vi /home/cit/darknet_path
+```
+darknet_path
+```
+/home/cit/darknet
 ```

--- a/bashrc
+++ b/bashrc
@@ -119,8 +119,9 @@ fi
 export GIT_SSL_NO_VERIFY=1
 
 # CUDA
-export PATH="/usr/local/cuda-8.0/bin:$PATH"
-export LD_LIBRARY_PATH="/usr/local/cuda-8.0/lib64:$LD_LIBRARY_PATH"
+DARKNET_PATH=`cat /home/cit/darknet_path`
+export PATH="/usr/local/cuda/bin:$PATH"
+export LD_LIBRARY_PATH="$DARKNET_PATH:/usr/local/cuda/lib64:$LD_LIBRARY_PATH"
 
 # Alias
 alias cmakeclean='rm -r CMakeCache.txt cmake_install.cmake; rm -r CMakeFiles; rm Makefile'

--- a/darknet_path
+++ b/darknet_path
@@ -1,0 +1,1 @@
+/home/cit/darknet

--- a/darknet_path
+++ b/darknet_path
@@ -1,1 +1,0 @@
-/home/cit/darknet


### PR DESCRIPTION
CUDAとDarknetのパスを変更した．

Darknetのパスは機体ごとに違うため，ローカルファイルの`/home/cit/darknet_path`の中にパスを書くことで対処