### PR TITLE
JetPack 4.2.2への対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,19 @@ $ git clone https://github.com/citbrains/dotfiles.git ~
 $ ln -s ~/dotfiles/bashrc ~/.bashrc
 $ ln -s ~/dotfiles/vimrc ~/.vimrc
 $ ln -s ~/dotfiles/tmux.conf ~/.tmux.conf
-$ # VNC autostart
-$ ln -s ~/dotfiles/config/autostart ~/.config/
 ```
 
-### Create a darknet_path
+### Scripts services install
+```
+$ sudo ln -s ~/dotfiles/scripts/services/autostartup.service /etc/systemd/system
+$ sudo ln -s ~/dotfiles/scripts/services/gnome-terminal.service /etc/systemd/system
+$ sudo ln -s ~/dotfiles/scripts/services/x11vnc.service /etc/systemd/system
+$ sudo systemctl enable autostartup
+$ sudo systemctl enable gnome-terminal
+$ sudo systemctl enable x11vnc
+```
+
+## Create a darknet_path
 ```bash
 $ vi /home/cit/darknet_path
 ```
@@ -23,9 +31,22 @@ darknet_path
 /home/cit/darknet
 ```
 
-### Script autostartup
-rc.local
+## Resolution Without Real Monitor(Virtual 1650x950).
+/etc/X11/xorg.conf
 ```
-# Script autostartup
-/home/cit/dotfiles/scripts/autostartup.sh &
+Section "Monitor"
+   Identifier "DSI-0"
+   Option    "Ignore"
+EndSection
+
+Section "Screen"
+   Identifier    "Default Screen"
+   Monitor        "Configured Monitor"
+   Device        "Default Device"
+   SubSection "Display"
+       Depth    24
+       Virtual 1650 950
+   EndSubSection
+EndSection
 ```
+https://devtalk.nvidia.com/default/topic/995621/jetson-tx1/jetson-tx1-desktop-sharing-resolution-problem-without-real-monitor/post/5159559/#5159559

--- a/bashrc
+++ b/bashrc
@@ -122,6 +122,7 @@ export GIT_SSL_NO_VERIFY=1
 DARKNET_PATH=`cat /home/cit/darknet_path`
 export PATH="/usr/local/cuda/bin:$PATH"
 export LD_LIBRARY_PATH="$DARKNET_PATH:/usr/local/cuda/lib64:$LD_LIBRARY_PATH"
+export EIGEN3_INCLUDE_DIR="/usr/include/eigen3"
 
 # Alias
 alias cmakeclean='rm -r CMakeCache.txt cmake_install.cmake; rm -r CMakeFiles; rm Makefile'

--- a/config/autostart/gnome-terminal.desktop
+++ b/config/autostart/gnome-terminal.desktop
@@ -1,8 +1,0 @@
-[Desktop Entry]
-Encoding=UTF-8
-Type=Application
-Name=GNOME-TERMINAL
-Comment=
-Exec=gnome-terminal --geometry=80x24+70+30 --working-directory=/home/cit/robocup/for2050/src/pyfiles
-StartupNotify=false
-Hidden=false

--- a/config/autostart/timeset.desktop
+++ b/config/autostart/timeset.desktop
@@ -1,9 +1,0 @@
-[Desktop Entry]
-Encoding=UTF-8
-Type=Application
-Name=TIMESET
-Comment=
-Exec=sudo /home/cit/dotfiles/scripts/timeset.sh
-StartupNotify=false
-Terminal=false
-Hidden=false

--- a/config/autostart/x11vnc.desktop
+++ b/config/autostart/x11vnc.desktop
@@ -1,9 +1,0 @@
-[Desktop Entry]
-Encoding=UTF-8
-Type=Application
-Name=X11VNC
-Comment=
-Exec=sudo x11vnc -nopw -display :0 -rfbport 5900 -geometry 1650x950 -forever -loop100 -xdamage -repeat -nevershared -noipv6
-StartupNotify=false
-Terminal=false
-Hidden=false

--- a/config/autostart/xrandr.desktop
+++ b/config/autostart/xrandr.desktop
@@ -1,9 +1,0 @@
-[Desktop Entry]
-Encoding=UTF-8
-Type=Application
-Name=XRANDR
-Comment=
-Exec=xrandr --fb 1650x950
-StartupNotify=false
-Terminal=false
-Hidden=false

--- a/scripts/autostartup.sh
+++ b/scripts/autostartup.sh
@@ -24,7 +24,7 @@ cpuon () {
 }
 
 jetson_clock () {
-	( /bin/sleep 60 && $HOME/jetson_clocks.sh )&
+	( /bin/sleep 60 && /usr/bin/jetson_clocks )&
 }
 
 time_setup () {

--- a/scripts/autostartup.sh
+++ b/scripts/autostartup.sh
@@ -24,7 +24,7 @@ cpuon () {
 }
 
 jetson_clock () {
-	( /bin/sleep 60 && $HOME/jetson_clocks.sh )
+	( /bin/sleep 60 && $HOME/jetson_clocks.sh )&
 }
 
 time_setup () {
@@ -34,8 +34,6 @@ time_setup () {
 }
 
 wifi_setup () {
-	/bin/sleep 5
-
 	# Power management OFF
 	/sbin/iw dev wlan0 set power_save off
 
@@ -44,14 +42,25 @@ wifi_setup () {
 	/sbin/iw phy0 set retry long 1
 }
 
+b3m_setup () {
+	modprobe ftdi_sio
+	echo "165c 0009" > /sys/bus/usb-serial/drivers/ftdi_sio/new_id
+}
+
+HPLStatusUI () {
+	/home/cit/robocup/for2050/src/pyfiles/pythonlauncher.sh &
+}
+
 root_check
 
 # System startup wait time.
-/bin/sleep 3
+/bin/sleep 10
 
-cpuon &
-#jetson_clock &
+cpuon
+#jetson_clock
 time_setup &
 wifi_setup &
+b3m_setup
+HPLStatusUI
 
 exit 0

--- a/scripts/gnome-terminal.sh
+++ b/scripts/gnome-terminal.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# System startup wait time.
+sleep 10
+# Specify display
+export DISPLAY=:0
+
+gnome-terminal --geometry=80x24+70+30 --working-directory=/home/cit/robocup/for2050/src/pyfiles &

--- a/scripts/services/autostartup.service
+++ b/scripts/services/autostartup.service
@@ -1,0 +1,12 @@
+[Unit]
+Description = Auto startups (cpu & time & wifi)
+
+[Service]
+Type = simple
+User = root
+Group = root
+KillMode = none
+ExecStart = /home/cit/dotfiles/scripts/autostartup.sh
+
+[Install]
+WantedBy = multi-user.target

--- a/scripts/services/gnome-terminal.service
+++ b/scripts/services/gnome-terminal.service
@@ -1,0 +1,12 @@
+[Unit]
+Description = terminal startup
+
+[Service]
+Type = simple
+User = cit
+Group = cit
+KillMode = none
+ExecStart = /home/cit/dotfiles/scripts/gnome-terminal.sh
+
+[Install]
+WantedBy = multi-user.target

--- a/scripts/services/x11vnc.service
+++ b/scripts/services/x11vnc.service
@@ -6,6 +6,7 @@ Type = simple
 User = cit
 Group = cit
 Restart = always
+KillMode = none
 ExecStart = /home/cit/dotfiles/scripts/x11vnc.sh
 
 [Install]

--- a/scripts/services/x11vnc.service
+++ b/scripts/services/x11vnc.service
@@ -1,0 +1,12 @@
+[Unit]
+Description = x11vnc startup
+
+[Service]
+Type = simple
+User = cit
+Group = cit
+Restart = always
+ExecStart = /home/cit/dotfiles/scripts/x11vnc.sh
+
+[Install]
+WantedBy = multi-user.target

--- a/scripts/timeset.sh
+++ b/scripts/timeset.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-date -s "$(ls -l --full-time /home/cit/robocup/for2050/src/ | grep CMakeFiles | awk '{print $6, $7}' | sed "s/[0-9][0-9]\.[0-9]*//g" | sed "s/://g" | sed "s/-//g")"

--- a/scripts/x11vnc.sh
+++ b/scripts/x11vnc.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-x11vnc_startup () {
-	/usr/bin/x11vnc -nopw -display :0 -rfbport 5900 -geometry 1650x950 -forever -loop100 -xdamage -repeat -nevershared
-}
-
 display_resolution () {
 	# System startup wait time.
 	/bin/sleep 5
@@ -13,7 +9,16 @@ display_resolution () {
 	/usr/bin/xrandr --fb 1650x950
 }
 
-display_resolution
+x11vnc_startup () {
+	# x11vnc kill all
+	sudo killall -KILL x11vnc
+
+	# x11vnc start
+	/usr/bin/x11vnc -nopw -display :0 -rfbport 5900 -geometry 1650x950 -forever -loop100 -xdamage -repeat -nevershared
+	#/usr/bin/x11vnc -nopw -display :0 -rfbport 5900 -forever -loop100 -xdamage -repeat -nevershared
+}
+
+#display_resolution
 x11vnc_startup
 
 exit 0

--- a/scripts/x11vnc.sh
+++ b/scripts/x11vnc.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+x11vnc_startup () {
+	/usr/bin/x11vnc -nopw -display :0 -rfbport 5900 -geometry 1650x950 -forever -loop100 -xdamage -repeat -nevershared
+}
+
+display_resolution () {
+	# System startup wait time.
+	/bin/sleep 5
+	# Specify display
+	export DISPLAY=:0
+
+	/usr/bin/xrandr --fb 1650x950
+}
+
+display_resolution
+x11vnc_startup
+
+exit 0


### PR DESCRIPTION
JetPack4.2.2への対応をしたのと，Ubuntu18.04からrc.localは非推奨になったのでスプリクトをサービス化しました．

実機で動作確認して，全機体にJetPack4.2.2を導入することになったらマージしたいと思います．